### PR TITLE
Multiple styling, layout, and content fixes from feedback

### DIFF
--- a/sakai-trinity/assignments/create.html
+++ b/sakai-trinity/assignments/create.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Sakai: Assignments (CALCULUS 1001 001 SP21)</title>
+		<title>Sakai: Assignments (CALCULUS 101 - 001 Sp21)</title>
 		<script type="module" src="../../sakai-trinity/components/sakai-header.js"></script>
         <script type="module" src="../../sakai-trinity/components/sakai-toolbar.js"></script>
         <script type="module" src="../../sakai-trinity/components/sakai-quicksidebar.js"></script>
@@ -21,7 +21,7 @@
 						<nav class="sakai-breadcrumbs">
 							<ul>
 								<li><a href="../index.html" class="sakai-breadcrumb">Home</a></li>
-								<li><a href="../courseIndex.html" class="sakai-breadcrumb">CALCULUS 1001 001 SP21</a></li>
+								<li><a href="../courseIndex.html" class="sakai-breadcrumb">CALCULUS 101 - 001 Sp21</a></li>
 								<li><a href="index.html" class="sakai-breadcrumb">Assignments</a></li>
 							</ul>
 							<h1>Create New Assignment</h1>

--- a/sakai-trinity/assignments/grader.html
+++ b/sakai-trinity/assignments/grader.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Sakai: Grading Assignment 1 Submissions (CALCULUS 1001 001 SP21)</title>
+		<title>Sakai: Grading Assignment 1 Submissions (CALCULUS 101 - 001 Sp21)</title>
 		<script type="module" src="../../sakai-trinity/components/sakai-header.js"></script>
         <script type="module" src="../../sakai-trinity/components/sakai-toolbar.js"></script>
         <script type="module" src="../../sakai-trinity/components/sakai-quicksidebar.js"></script>
@@ -21,7 +21,7 @@
 						<nav class="sakai-breadcrumbs">
 							<ul>
 								<li><a href="../index.html" class="sakai-breadcrumb">Home</a></li>
-								<li><a href="../courseIndex.html" class="sakai-breadcrumb">CALCULUS 1001 001 SP21</a></li>
+								<li><a href="../courseIndex.html" class="sakai-breadcrumb">CALCULUS 101 - 001 Sp21</a></li>
 								<li><a href="index.html" class="sakai-breadcrumb">Assignments</a></li>
 								<li><a href="submissions.html" class="sakai-breadcrumb">Assignment 1 Submissions</a></li>
 							</ul>
@@ -42,7 +42,7 @@
 								<label for="viewFilter_viewFilterForm">Filter by</label>
 								<select id="viewFilter_viewFilterForm" name="view">
 									<option value="all" selected="selected">Entire Site</option>
-									<option value="CALCULUS1001001SP21">CALCULUS 1001 001 SP21</option>
+									<option value="CALCULUS1001001SP21">CALCULUS 101 - 001 Sp21</option>
 								</select>
 							</div>
 							<div class="sakai-table-viewFilter">
@@ -72,7 +72,7 @@
 									<option value="9">Lovellette, Moshe (student0015)</option>
 									<option value="10">Niño, El (student0008)</option>
 								</select>
-								<input type="button" class="sakai-table-pagerControls-next" value=">" title="Next oage">
+								<input type="button" class="sakai-table-pagerControls-next" value=">" title="Next page">
 							</div>
 						</div>
 					</div>

--- a/sakai-trinity/assignments/index-original.html
+++ b/sakai-trinity/assignments/index-original.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Sakai: Assignment 1 Submissions (CALCULUS 1001 001 SP21)</title>
+		<title>Sakai: Assignment 1 Submissions (CALCULUS 101 - 001 Sp21)</title>
 		<link type="text/css" rel="stylesheet" href="styles.css">
 	</head>
 
@@ -38,7 +38,7 @@
 						<a class="sakai-sitesNav__favbtn fav" href="#" data-site-id="CMKL_807G_4344" role="switch" aria-checked="true" title="Toggle CMKL_807G_4344 as a favorite site"></a>
 						<a class="link-container" href="#" title="CMKL_807G_4344">
 							<!-- <img class="icon" src="../icons/caret-forward-outline.svg" title="Open menu"> -->
-							<span>CALCULUS 1001 001 SP21</span>
+							<span>CALCULUS 101 - 001 Sp21</span>
 						</a>
 						<a class="sakai-sitesNav__dropdown" href="#" data-site-id="CMKL_807G_4344" aria-haspopup="true" title="Open attached menu for CMKL_807G_4344 to access its tools"></a>
 						<ul class="sakai-sitesNav__submenu" role="menu">
@@ -283,7 +283,7 @@
 						<nav class="sakai-breadcrumbs">
 							<ul>
 								<li><a href="#" class="sakai-breadcrumb">Sakai</a></li>
-								<li><a href="#" class="sakai-breadcrumb">CALCULUS 1001 001 SP21</a></li>
+								<li><a href="#" class="sakai-breadcrumb">CALCULUS 101 - 001 Sp21</a></li>
 								<li><a href="#" class="sakai-breadcrumb">Assignments</a></li>
 							</ul>
 							<h1>Assignment 1 Submissions</h1>
@@ -303,7 +303,7 @@
 								<label for="viewFilter_viewFilterForm">Filter by</label>
 								<select id="viewFilter_viewFilterForm" name="view">
 									<option value="all" selected="selected">Entire Site</option>
-									<option value="CALCULUS1001001SP21">CALCULUS 1001 001 SP21</option>
+									<option value="CALCULUS1001001SP21">CALCULUS 101 - 001 Sp21</option>
 								</select>
 							</div>
 							<div class="sakai-table-searchFilter">
@@ -326,7 +326,7 @@
 									<option value="100">Show 100</option>
 									<option value="200">Show 200</option>
 								</select>
-								<input type="button" class="sakai-table-pagerControls-next" value=">" title="Next oage">
+								<input type="button" class="sakai-table-pagerControls-next" value=">" title="Next page">
 							</div>
 						</div>
 					</div>

--- a/sakai-trinity/assignments/index.html
+++ b/sakai-trinity/assignments/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Sakai: Assignments (CALCULUS 1001 001 SP21)</title>
+		<title>Sakai: Assignments (CALCULUS 101 - 001 Sp21)</title>
 		<script type="module" src="../../sakai-trinity/components/sakai-header.js"></script>
         <script type="module" src="../../sakai-trinity/components/sakai-toolbar.js"></script>
         <script type="module" src="../../sakai-trinity/components/sakai-quicksidebar.js"></script>
@@ -22,7 +22,7 @@
 						<nav class="sakai-breadcrumbs">
 							<ul>
 								<li><a href="../index.html" class="sakai-breadcrumb">Home</a></li>
-								<li><a href="../courseIndex.html" class="sakai-breadcrumb">CALCULUS 1001 001 SP21</a></li>
+								<li><a href="../courseIndex.html" class="sakai-breadcrumb">CALCULUS 101 - 001 Sp21</a></li>
 							</ul>
 							<h1>Assignments</h1>
 						</nav>
@@ -41,7 +41,7 @@
 								<label for="viewFilter_viewFilterForm">Filter by</label>
 								<select id="viewFilter_viewFilterForm" name="view">
 									<option value="all" selected="selected">Entire Site</option>
-									<option value="CALCULUS1001001SP21">CALCULUS 1001 001 SP21</option>
+									<option value="CALCULUS1001001SP21">CALCULUS 101 - 001 Sp21</option>
 									<option value="group1">Group 1</option>
 									<option value="group2">Group 2</option>
 									<option value="group3">Group 3</option>
@@ -69,7 +69,7 @@
 									<option value="100">Show 100</option>
 									<option value="200">Show 200</option>
 								</select>
-								<input type="button" class="sakai-table-pagerControls-next" value=">" title="Next oage">
+								<input type="button" class="sakai-table-pagerControls-next" value=">" title="Next page">
 							</div>
 						</div>
 					</div>

--- a/sakai-trinity/assignments/submissions.html
+++ b/sakai-trinity/assignments/submissions.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Sakai: Assignment 1 Submissions (CALCULUS 1001 001 SP21)</title>
+		<title>Sakai: Assignment 1 Submissions (CALCULUS 101 - 001 Sp21)</title>
 		<script type="module" src="../../sakai-trinity/components/sakai-header.js"></script>
         <script type="module" src="../../sakai-trinity/components/sakai-toolbar.js"></script>
         <script type="module" src="../../sakai-trinity/components/sakai-quicksidebar.js"></script>
@@ -22,7 +22,7 @@
 						<nav class="sakai-breadcrumbs">
 							<ul>
 								<li><a href="../index.html" class="sakai-breadcrumb">Home</a></li>
-								<li><a href="../courseIndex.html" class="sakai-breadcrumb">CALCULUS 1001 001 SP21</a></li>
+								<li><a href="../courseIndex.html" class="sakai-breadcrumb">CALCULUS 101 - 001 Sp21</a></li>
 								<li><a href="index.html" class="sakai-breadcrumb">Assignments</a></li>
 							</ul>
 							<h1>Assignment 1 Submissions</h1>
@@ -42,7 +42,7 @@
 								<label for="viewFilter_viewFilterForm">Filter by</label>
 								<select id="viewFilter_viewFilterForm" name="view">
 									<option value="all" selected="selected">Entire Site</option>
-									<option value="CALCULUS1001001SP21">CALCULUS 1001 001 SP21</option>
+									<option value="CALCULUS1001001SP21">CALCULUS 101 - 001 Sp21</option>
 								</select>
 							</div>
 							<div class="sakai-table-searchFilter">
@@ -66,7 +66,7 @@
 									<option value="100">Show 100</option>
 									<option value="200">Show 200</option>
 								</select>
-								<input type="button" class="sakai-table-pagerControls-next" value=">" title="Next oage">
+								<input type="button" class="sakai-table-pagerControls-next" value=">" title="Next page">
 							</div>
 						</div>
 					</div>
@@ -84,8 +84,8 @@
 							<tr>
 								<th class="sakai-table-selectItem"><input type="checkbox"></th>
 								<th><a href="#">Student Name</a></th>
-								<th><a href="#">Submitted Date</a></th>
 								<th class="sakai-table-statusItem"><a href="#">Status</a></th>
+								<th><a href="#">Submitted Date</a></th>
 								<th class="sakai-table-gradeItem"><a href="#">Grade</a></th>
 								<th><a href="#">Released</a></th>
 							</tr>
@@ -94,90 +94,89 @@
 							<tr>
 								<td class="sakai-table-selectItem"><input type="checkbox"></td>
 								<td><a href="grader.html">Albertson, Albert (student0011)</a></td>
-								<td>March 31, 2021 4:59pm</td>
 								<td class="sakai-table-statusItem"><span class="sakai-status-success">Submitted</span></td>
+								<td>March 31, 2021 4:59pm</td>
 								<td class="sakai-table-gradeItem">-- / 100</td>
 								<td></td>
 							</tr>
 							<tr>
 								<td class="sakai-table-selectItem"><input type="checkbox"></td>
 								<td><a href="grader.html">Anderson, Zachary (student0012)</a></td>
-								<td>--</td>
 								<td class="sakai-table-statusItem"><span class="sakai-status-error">No Submission</span></td>
+								<td>--</td>
 								<td class="sakai-table-gradeItem">0 / 100</td>
 								<td>Released</td>
 							</tr>
 							<tr>
 								<td class="sakai-table-selectItem"><input type="checkbox"></td>
 								<td><a href="grader.html">Bhayakridbhayanashanachar, Bhaktavatsalam (student0014)</a></td>
-								<td>March 31, 2021 4:32pm</td>
 								<td class="sakai-table-statusItem"><span class="sakai-status-success">Submitted</span></td>
+								<td>March 31, 2021 4:32pm</td>
 								<td class="sakai-table-gradeItem">89 / 100</td>
 								<td>Released</td>
 							</tr>
 							<tr>
 								<td class="sakai-table-selectItem"><input type="checkbox"></td>
 								<td><a href="grader.html">de L'Aigle, Aimee (student0005)</a></td>
-								<td>March 31, 2021 4:49pm</td>
 								<td class="sakai-table-statusItem"><span class="sakai-status-success">Submitted</span></td>
+								<td>March 31, 2021 4:49pm</td>
 								<td class="sakai-table-gradeItem">75 / 100</td>
 								<td>Released</td>
 							</tr>
 							<tr>
 								<td class="sakai-table-selectItem"><input type="checkbox"></td>
 								<td><a href="grader.html">der Pluijm, Ben van (student0003)</a></td>
-								<td>March 31, 2021 4:41pm</td>
 								<td class="sakai-table-statusItem"><span class="sakai-status-success">Submitted</span></td>
+								<td>March 31, 2021 4:41pm</td>
 								<td class="sakai-table-gradeItem">-- / 100</td>
 								<td></td>
 							</tr>
 							<tr>
 								<td class="sakai-table-selectItem"><input type="checkbox"></td>
 								<td><a href="grader.html">Fitz Gerald, John (student0007)</a></td>
-								<td>March 31, 2021 5:01pm</td>
 								<td class="sakai-table-statusItem"><span class="sakai-status-warn">Submitted - Late</span></td>
+								<td>March 31, 2021 5:01pm</td>
 								<td class="sakai-table-gradeItem">49 / 100</td>
 								<td>Released</td>
 							</tr>
 							<tr>
 								<td class="sakai-table-selectItem"><input type="checkbox"></td>
 								<td><a href="grader.html">Haslip, Ângeolo (student0009)</a></td>
-								<td>March 31, 2021 4:55pm</td>
 								<td class="sakai-table-statusItem"><span class="sakai-status-success">Submitted</span></td>
+								<td>March 31, 2021 4:55pm</td>
 								<td class="sakai-table-gradeItem">85 / 100</td>
 								<td>Released</td>
 							</tr>
 							<tr>
 								<td class="sakai-table-selectItem"><input type="checkbox"></td>
 								<td><a href="grader.html">Kar-Wai, Wong (student0006)</a></td>
-								<td>March 31, 2021 3:31pm</td>
 								<td class="sakai-table-statusItem"><span class="sakai-status-success">Submitted</span></td>
+								<td>March 31, 2021 3:31pm</td>
 								<td class="sakai-table-gradeItem">51 / 100</td>
 								<td>Released</td>
 							</tr>
 							<tr>
 								<td class="sakai-table-selectItem"><input type="checkbox"></td>
 								<td><a href="grader.html">Lovellette, Moshe (student0015)</a></td>
-								<td>March 31, 2021 5:02pm</td>
 								<td class="sakai-table-statusItem"><span class="sakai-status-warn">Submitted - Late</span></td>
+								<td>March 31, 2021 5:02pm</td>
 								<td class="sakai-table-gradeItem">-- / 100</td>
 								<td></td>
 							</tr>
 							<tr>
 								<td class="sakai-table-selectItem"><input type="checkbox"></td>
 								<td><a href="grader.html">Niño, El (student0008)</a></td>
-								<td>March 31, 2021 4:58pm</td>
 								<td class="sakai-table-statusItem"><span class="sakai-status-success">Submitted</span></td>
+								<td>March 31, 2021 4:58pm</td>
 								<td class="sakai-table-gradeItem">-- / 100</td>
 								<td></td>
 							</tr>
 						</tbody>
 					</table>
 					<sakai-pagination class="sakai-table-endBar" count="19" current="1"></sakai-pagination>
-
+				</div>
 				<sakai-footer></sakai-footer>
 			</div>
-		</div>
 		<script src="../../sakai-trinity/scripts.js"></script>
 	</body>
 </html>

--- a/sakai-trinity/assignments/template.html
+++ b/sakai-trinity/assignments/template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
-		<title>Sakai: PAGETITLEHERE (CALCULUS 1001 001 SP21)</title>
+		<title>Sakai: PAGETITLEHERE (CALCULUS 101 - 001 Sp21)</title>
 		<script type="module" src="../../sakai-trinity/components/sakai-header.js"></script>
         <script type="module" src="../../sakai-trinity/components/sakai-toolbar.js"></script>
         <script type="module" src="../../sakai-trinity/components/sakai-quicksidebar.js"></script>
@@ -23,7 +23,7 @@
 						  <ul>
 							<li><a href="#" class="sakai-breadcrumb">Sakai</a></li>
 							<li>
-							  <a href="#" class="sakai-breadcrumb">CALCULUS 1001 001 SP21</a>
+							  <a href="#" class="sakai-breadcrumb">CALCULUS 101 - 001 Sp21</a>
 							</li>
 							<li>
 							  <a href="index.html" class="sakai-breadcrumb">Assignments</a>

--- a/sakai-trinity/components/sakai-card.css
+++ b/sakai-trinity/components/sakai-card.css
@@ -1,3 +1,6 @@
 :host {
   display: flex;
 }
+img {
+  max-width: 100%;
+}

--- a/sakai-trinity/components/sakai-header.css
+++ b/sakai-trinity/components/sakai-header.css
@@ -10,7 +10,7 @@ header {
 ion-icon {
   color: white;
   /* --ionicon-stroke-width: 16px; */
-  font-size: 40px;
+  font-size: 44px;
 }
 li {
   list-style: none;
@@ -46,11 +46,9 @@ input[type='date'] {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
   margin: 0 4px;
   overflow: hidden;
-  border-radius: 20px;
+  border-radius: 50%;
   font-size: 0;
   text-decoration: none;
 }
@@ -66,6 +64,7 @@ input[type='date'] {
   display: block;
   width: calc(var(--toolBarOpenWidth) - 40px);
   height: 50px;
+  margin-left: -44px;
   background: url('../images/logo-jewel.png') no-repeat center center;
   background-size: auto 40px;
   font-size: 0;
@@ -84,13 +83,17 @@ input[type='date'] {
 
 .sakai-systemIndicators {
   display: flex;
-  margin: 0;
+  align-items: center;
+  margin: 0 16px 0 0;
   padding: 0;
   color: #fff;
 }
 .sak-sysInd-account {
   box-sizing: border-box;
-  border: 2px solid #fff;
+  width: 36px;
+  height: 36px;
+  margin: 0 0 0 8px;
+  border: 3px solid #fff;
 }
 .sak-sysInd-account img {
   filter: none;

--- a/sakai-trinity/components/sakai-header.js
+++ b/sakai-trinity/components/sakai-header.js
@@ -59,7 +59,7 @@ export class SakaiHeader extends LitElement {
         <nav class="sakai-breadcrumbs">
           <ul>
             <li><a href="../index.html" class="sakai-breadcrumb">Home</a></li>
-            <li><a href="../courseIndex.html" class="sakai-breadcrumb">CALCULUS 1001 001 SP21</a></li>
+            <li><a href="../courseIndex.html" class="sakai-breadcrumb">CALCULUS 101 - 001 Sp21</a></li>
             <li>Assignments</li>
 					</ul>
 				</nav>

--- a/sakai-trinity/components/sakai-pagination.js
+++ b/sakai-trinity/components/sakai-pagination.js
@@ -24,6 +24,9 @@ export class SakaiPagination extends LionPagination {
           -moz-appearance: none;
           -webkit-appearance: none;
         }
+        ul {
+            margin: 0;
+        }
         li:first-of-type button {
           background-image: url('/sakai-trinity/icons/chevron-back-outline.svg');
         }

--- a/sakai-trinity/components/sakai-toolbar-site.css
+++ b/sakai-trinity/components/sakai-toolbar-site.css
@@ -32,7 +32,7 @@ a:visited {
   margin-top: 0;
 }
 .sakai-sitesNav__submenuitem {
-  margin: 4px 0;
+  margin: 0;
   list-style: none;
   display: block;
 }
@@ -51,11 +51,13 @@ a:visited {
   text-decoration: none;
 }
 .sakai-sitesNav__submenuitem-link {
-  padding: 4px;
-  padding-left: 16px;
-  display: block;
+  display: flex;
+  align-items: center;
+  padding: 8px 8px 8px 16px;
 }
-
+.sakai-sitesNav__submenuitem-link ion-icon {
+    margin-right: 8px;
+}
 .sakai-sitesNav__submenuitem-title {
   display: inline-block;
 }

--- a/sakai-trinity/components/sakai-widget-user.js
+++ b/sakai-trinity/components/sakai-widget-user.js
@@ -32,28 +32,28 @@ export class SakaiWidgetUser extends LitElement {
       </div>
       <ul class="userNav" role="menu">
         <li class="sakai-userNav__submenuitem">
-          <a href="#" class="sakai-headerItem">Account Info</a>
+          <a href="#" class="sakai-userNav__link">Account Info</a>
         </li>
         <li class="sakai-userNav__submenuitem">
-          <a href="#" class="sakai-headerItem">Profile</a>
+          <a href="#" class="sakai-userNav__link">Profile</a>
         </li>
         <li class="sakai-userNav__submenuitem">
-          <a href="#" class="sakai-headerItem">My Connections</a>
+          <a href="#" class="sakai-userNav__link">My Connections</a>
         </li>
         <li class="sakai-userNav__submenuitem">
-          <a href="#" class="sakai-headerItem">Calendar</a>
+          <a href="#" class="sakai-userNav__link">Calendar</a>
         </li>
         <li class="sakai-userNav__submenuitem">
-          <a href="#" class="sakai-headerItem">Preferences</a>
+          <a href="#" class="sakai-userNav__link">Preferences</a>
         </li>
         <li class="sakai-userNav__submenuitem">
-          <a href="#" class="sakai-headerItem">Tutorial</a>
+          <a href="#" class="sakai-userNav__link">Tutorial</a>
         </li>
         <li class="sakai-userNav__submenuitem">
-          <a href="#" class="sakai-headerItem">Themes</a>
+          <a href="#" class="sakai-userNav__link">Themes</a>
         </li>
         <li class="sakai-userNav__submenuitem">
-          <a href="#" class="sakai-headerItem">Log Out</a>
+          <a href="#" class="sakai-userNav__link">Log Out</a>
         </li>
       </ul>
     `;

--- a/sakai-trinity/courseIndex.html
+++ b/sakai-trinity/courseIndex.html
@@ -22,7 +22,7 @@
 						<nav class="sakai-breadcrumbs">
 							<ul>
 								<li><a href="index.html" class="sakai-breadcrumb">Home</a></li>
-								<li><a href="courseIndex.html" class="sakai-breadcrumb">CALCULUS 1001 001 SP21</a></li>
+								<li><a href="courseIndex.html" class="sakai-breadcrumb">CALCULUS 101 - 001 Sp21</a></li>
 							</ul>
 							<h1>Dashboard</h1>
 						</nav>

--- a/sakai-trinity/index.html
+++ b/sakai-trinity/index.html
@@ -30,7 +30,7 @@
 						<div class="sakai-dashboard-sitesContainer">
 							<div class="sakai-dashboard-siteCard">
 								<h2><a href="courseIndex.html">Introduction to Calculus</a></h2>
-								<h3>CALCULUS 1001 001 SP21</h3>
+								<h3>CALCULUS 101 - 001 Sp21</h3>
 								<div class="sakai-dashboard-siteCard-iconBar">
 									<span class="sakai-dashboard-siteCard-toolIconIndicator"></span>
 									<span class="sakai-dashboard-siteCard-toolIconIndicator"></span>

--- a/sakai-trinity/membership.html
+++ b/sakai-trinity/membership.html
@@ -43,7 +43,7 @@
                       <div class="sakai-dashboard-sitesContainer">
                           <div class="sakai-dashboard-siteCard">
                               <h2><a href="courseIndex.html">Introduction to Calculus</a></h2>
-                              <h3>CALCULUS 1001 001 SP21</h3>
+                              <h3>CALCULUS 101 - 001 Sp21</h3>
       
                           </div>
                           <div class="sakai-dashboard-siteCard">
@@ -68,7 +68,7 @@
                           </div>
                           <div class="sakai-dashboard-siteCard">
                               <h2><a href="courseIndex.html">Introduction to Calculus</a></h2>
-                              <h3>CALCULUS 1001 001 SP21</h3>
+                              <h3>CALCULUS 101 - 001 Sp21</h3>
       
                           </div>
                           <div class="sakai-dashboard-siteCard">
@@ -93,7 +93,7 @@
                           </div>
                           <div class="sakai-dashboard-siteCard">
                               <h2><a href="courseIndex.html">Introduction to Calculus</a></h2>
-                              <h3>CALCULUS 1001 001 SP21</h3>
+                              <h3>CCALCULUS 101 - 001 Sp21</h3>
       
                           </div>
                           <div class="sakai-dashboard-siteCard">
@@ -123,7 +123,7 @@
                           <h6>Will show up on the left of each page</h6>
                           <div class="sakai-dashboard-siteCard">
                             <h2><a href="courseIndex.html">Introduction to Calculus</a></h2>
-                            <h3>CALCULUS 1001 001 SP21</h3>
+                            <h3>CALCULUS 101 - 001 Sp21</h3>
     
                         </div>
                         <div class="sakai-dashboard-siteCard">

--- a/sakai-trinity/styles.css
+++ b/sakai-trinity/styles.css
@@ -184,8 +184,6 @@ select {
 }
 .sakai-toolOptions {
   margin-top: 8px;
-  /* border: 0 none; */
-  text-align: right;
 }
 .sakai-toolOptions::before {
   content: '';
@@ -274,7 +272,7 @@ button.primary,
 .sakai-table-searchFilter {
   flex-grow: 1;
 }
-.sakai-table-searchFilter-searchField {
+input.sakai-table-searchFilter-searchField {
   flex-grow: 1;
   width: 200px;
   margin-right: 4px;


### PR DESCRIPTION
- fixed spelling typo of "page" for Next Page pagination
- fixed footer hierarchy on Submissions page
- fixed Options menu text alignment in Firefox
- fixed the height of the Search field
- moved Submitted Status column one column to the left
- aligned the icons in the tool menu
- tried to make the account menu and the header icons the same size
- spaced out the header icons evenly
- centered the Sakai logo
- standardized the name of our example course to "CALCULUS 101 - 001 Sp21" in all places