### PR TITLE
Updated initial Bootstrap mockup with changes from feedback received this week

### DIFF
--- a/sakai-trinity/bootstrap/index.html
+++ b/sakai-trinity/bootstrap/index.html
@@ -15,16 +15,16 @@
   </head>
   <body>
     <div class="sakai-jumpLinks visually-hidden-focusable overflow-hidden bg-primary">
-      <a class="d-inline-flex mx-2 p-3" href="#mainContent">Jump to the main content</a>
-      <a class="d-inline-flex mx-2 p-3" href="#currentSitesTools">Jump to the current site's tools</a>
-      <a class="d-inline-flex mx-2 p-3" href="#sitesList">Jump to the sites list</a>
+      <a class="d-inline-flex mx-2 my-1 p-3" href="#mainContent">Jump to the main content</a>
+      <a class="d-inline-flex mx-2 my-1 p-3" href="#currentSitesTools">Jump to the current site's tools</a>
+      <a class="d-inline-flex mx-2 my-1 p-3" href="#sitesList">Jump to the sites list</a>
     </div>
-    <div class="sakai-pa alert alert-warning alert-dismissible fade show visually-hidden d-flex justify-content-center m-0">
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-exclamation-triangle-fill flex-shrink-0 me-2" viewBox="0 0 16 16" role="img" aria-label="Warning:">
+    <div class="sakai-pa alert alert-warning alert-dismissible fade show d-none justify-content-center m-0">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-exclamation-triangle-fill flex-shrink-0 me-2" viewBox="0 0 16 16" role="img" aria-label="Warning icon">
         <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
       </svg>
       <p class="m-0"><strong>Upcoming maintenance: </strong>Sakai will be unavailable temporarily on Sunday at 10am for system maintenance</p>
-      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Dismiss this alert"></button>
     </div>
     <div class="sakai-portalContainer">
       
@@ -36,14 +36,16 @@
               <a href="/sakai-trinity/index.html" class="sakai-headerLogo--institution">Sakai</a>
           </div>-->
           <a href="index.html" class="px-3"><img src="images/logo-jewel.png" alt="Sakai logo"><span class="visually-hidden">Home</span></a>
+
           <a href="#" class="p-3 text-muted">
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-list" viewBox="0 0 16 16">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-list" viewBox="0 0 16 16"  role="img" aria-label="Collapse icon" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Collapse the sidebar">
               <path fill-rule="evenodd" d="M2.5 12a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5zm0-4a.5.5 0 0 1 .5-.5h10a.5.5 0 0 1 0 1H3a.5.5 0 0 1-.5-.5z"/>
             </svg>
+            <span class="visually-hidden">Collapse sites sidebar</span>
           </a>
         </div>
 
-        <div class="sakai-headerSearch d-none d-lg-flex flex-grow-1 align-items-center justify-content-start">
+        <div class="sakai-headerSearch d-none flex-grow-1 align-items-center justify-content-start">
           <div class="input-group position-relative w-50 mx-3">
             <input type="text" class="sakaiSearch form-control">
             <i class="bi bi-search position-absolute start-0 top-50 translate-middle ms-3"></i>
@@ -51,46 +53,55 @@
           </div>
         </div>
         
+        <a href="#" class="sak-sysInd-systemAlerts nav-link d-flex align-items-center text-white me-auto" onclick="alert('Somehow we will get the dismissed PA System alert to re-appear');">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-exclamation-diamond me-1 text-warning" viewBox="0 0 16 16">
+            <path d="M6.95.435c.58-.58 1.52-.58 2.1 0l6.515 6.516c.58.58.58 1.519 0 2.098L9.05 15.565c-.58.58-1.519.58-2.098 0L.435 9.05a1.482 1.482 0 0 1 0-2.098L6.95.435zm1.4.7a.495.495 0 0 0-.7 0L1.134 7.65a.495.495 0 0 0 0 .7l6.516 6.516a.495.495 0 0 0 .7 0l6.516-6.516a.495.495 0 0 0 0-.7L8.35 1.134z"/>
+            <path d="M7.002 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 4.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 4.995z"/>
+          </svg>
+          <span class="d-none d-md-inline">View System Alert</span>
+        </a>
+        
         <ul class="sakai-systemIndicators nav flex-nowrap align-items-center">
           <li>
-            <div tabindex="0" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Help">
-              <a class="sak-sysInd-help nav-link text-white" data-bs-toggle="offcanvas" href="#sakai-contextualHelpPanel" role="button" aria-controls="sakai-contextualHelpPanel">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-question-circle d-block mx-auto mb-1" viewBox="0 0 16 16" role="img" aria-label="Help">
-                  <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
-                  <path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286zm1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94z"/>
-                </svg>
-              </a>
-            </div>
+            <a class="sak-sysInd-help nav-link text-white" data-bs-toggle="offcanvas" href="#sakai-contextualHelpPanel" role="button" aria-controls="sakai-contextualHelpPanel">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-question-circle" viewBox="0 0 16 16" role="img" aria-label="View contextual help for this page" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Help">
+                <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+                <path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286zm1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94z"/>
+              </svg>
+            </a>
           </li>
           <li>
-            <div tabindex="0" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Quick Links">
-              <a class="sak-sysInd-notifications nav-link text-white position-relative" data-bs-toggle="offcanvas" href="#sakai-quickLinksPanel" role="button" aria-controls="sakai-quickLinksPanel">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-link-45deg" viewBox="0 0 16 16">
-                  <path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1.002 1.002 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4.018 4.018 0 0 1-.128-1.287z"/>
-                  <path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243L6.586 4.672z"/>
-                </svg>
-              </a>
-            </div>
+            <a class="sak-sysInd-search nav-link text-white" data-bs-toggle="offcanvas" href="#sakai-searchPanel" role="button" aria-controls="sakai-searchPanel">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-search" viewBox="0 0 16 16" role="img" aria-label="Search Sakai" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Search">
+                <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001c.03.04.062.078.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1.007 1.007 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
+              </svg>
+            </a>
           </li>
           <li>
-            <a href="#" class="sak-sysInd-systemAlerts nav-link text-white" onclick="alert('Somehow we will get the dismissed PA System alert to re-appear');" data-bs-toggle="tooltip" data-bs-placement="bottom" title="System Alerts">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-exclamation-diamond" viewBox="0 0 16 16">
+            <a class="sak-sysInd-notifications nav-link text-white position-relative" data-bs-toggle="offcanvas" href="#sakai-quickLinksPanel" role="button" aria-controls="sakai-quickLinksPanel">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-link-45deg" viewBox="0 0 16 16" role="img" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Quick Links">
+                <path d="M4.715 6.542 3.343 7.914a3 3 0 1 0 4.243 4.243l1.828-1.829A3 3 0 0 0 8.586 5.5L8 6.086a1.002 1.002 0 0 0-.154.199 2 2 0 0 1 .861 3.337L6.88 11.45a2 2 0 1 1-2.83-2.83l.793-.792a4.018 4.018 0 0 1-.128-1.287z"/>
+                <path d="M6.586 4.672A3 3 0 0 0 7.414 9.5l.775-.776a2 2 0 0 1-.896-3.346L9.12 3.55a2 2 0 1 1 2.83 2.83l-.793.792c.112.42.155.855.128 1.287l1.372-1.372a3 3 0 1 0-4.243-4.243L6.586 4.672z"/>
+              </svg>
+            </a>
+          </li>
+          <li>
+            <a href="#" class="sak-sysInd-systemAlerts nav-link text-white d-none" onclick="alert('Somehow we will get the dismissed PA System alert to re-appear');">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-exclamation-diamond" viewBox="0 0 16 16" role="img" tabindex="0" data-bs-toggle="tooltip" data-bs-placement="bottom" title="System Alerts">
                 <path d="M6.95.435c.58-.58 1.52-.58 2.1 0l6.515 6.516c.58.58.58 1.519 0 2.098L9.05 15.565c-.58.58-1.519.58-2.098 0L.435 9.05a1.482 1.482 0 0 1 0-2.098L6.95.435zm1.4.7a.495.495 0 0 0-.7 0L1.134 7.65a.495.495 0 0 0 0 .7l6.516 6.516a.495.495 0 0 0 .7 0l6.516-6.516a.495.495 0 0 0 0-.7L8.35 1.134z"/>
                 <path d="M7.002 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 4.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 4.995z"/>
               </svg>
             </a>
           </li>
           <li>
-            <div tabindex="0" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Notifications">
-              <a class="sak-sysInd-notifications nav-link text-white position-relative" data-bs-toggle="offcanvas" href="#sakai-notificationsPanel" role="button" aria-controls="sakai-notificationsPanel">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-bell d-block mx-auto mb-1" viewBox="0 0 16 16" role="img" aria-label="Notifications">
-                  <path d="M8 16a2 2 0 0 0 2-2H6a2 2 0 0 0 2 2zM8 1.918l-.797.161A4.002 4.002 0 0 0 4 6c0 .628-.134 2.197-.459 3.742-.16.767-.376 1.566-.663 2.258h10.244c-.287-.692-.502-1.49-.663-2.258C12.134 8.197 12 6.628 12 6a4.002 4.002 0 0 0-3.203-3.92L8 1.917zM14.22 12c.223.447.481.801.78 1H1c.299-.199.557-.553.78-1C2.68 10.2 3 6.88 3 6c0-2.42 1.72-4.44 4.005-4.901a1 1 0 1 1 1.99 0A5.002 5.002 0 0 1 13 6c0 .88.32 4.2 1.22 6z"/>
-                </svg>
-                <span class="sakai-newNotificationsIndicator p-1 bg-danger rounded-circle">
-                  <span class="visually-hidden">New alerts</span>
-                </span>
-              </a>
-            </div>
+            <a class="sak-sysInd-notifications nav-link text-white position-relative" data-bs-toggle="offcanvas" href="#sakai-notificationsPanel" role="button" aria-controls="sakai-notificationsPanel">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-bell" viewBox="0 0 16 16" role="img" aria-label="View notifications" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Notifications">
+                <path d="M8 16a2 2 0 0 0 2-2H6a2 2 0 0 0 2 2zM8 1.918l-.797.161A4.002 4.002 0 0 0 4 6c0 .628-.134 2.197-.459 3.742-.16.767-.376 1.566-.663 2.258h10.244c-.287-.692-.502-1.49-.663-2.258C12.134 8.197 12 6.628 12 6a4.002 4.002 0 0 0-3.203-3.92L8 1.917zM14.22 12c.223.447.481.801.78 1H1c.299-.199.557-.553.78-1C2.68 10.2 3 6.88 3 6c0-2.42 1.72-4.44 4.005-4.901a1 1 0 1 1 1.99 0A5.002 5.002 0 0 1 13 6c0 .88.32 4.2 1.22 6z"/>
+              </svg>
+              <span class="sakai-newNotificationsIndicator p-1 bg-danger rounded-circle">
+                <span class="visually-hidden">There are new notifications available</span>
+              </span>
+            </a>
           </li>
           <li>
             <a class="sak-sysInd-account nav-link text-white" data-bs-toggle="offcanvas" href="#sakai-accountPanel" role="bottom" aria-controls="sakai-accountPanel" title="Account">
@@ -102,7 +113,7 @@
         <div class="offcanvas offcanvas-end" tabindex="-1" id="sakai-contextualHelpPanel" aria-labelledby="sakai-contextualHelpPanelLabel">
           <div class="offcanvas-header">
             <h2 class="offcanvas-title" id="sakai-contextualHelpPanelLabel">Help: Assignments</h2>
-            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close this help panel"></button>
           </div>
           <div class="offcanvas-body">
             <h3>Introduction</h3>
@@ -119,11 +130,26 @@
             <p class="text-end"><a href="https://sakai.screenstepslive.com/s/sakai_help/m/101295/l/1339923-what-is-the-assignments-tool" target="_blank">Learn more...</a></p>
           </div>
         </div>
+
+        <div class="offcanvas offcanvas-end" tabindex="-1" id="sakai-searchPanel" aria-labelledby="sakai-searchPanelLabel">
+          <div class="offcanvas-header">
+            <h2 class="offcanvas-title" id="sakai-searchPanelLabel">Search Sakai</h2>
+            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close this search panel"></button>
+          </div>
+          <div class="offcanvas-body">
+            <label class="visually-hidden" for="sakai-searchField">Enter search term to search Sakai</label>
+            <div class="input-group position-relative">
+              <input type="text" id="sakai-searchField" class="sakaiSearch form-control">
+              <i class="bi bi-search position-absolute start-0 top-50 translate-middle ms-3"></i>
+              <button type="button" class="btn btn-primary">Search Sakai</button>
+            </div>
+          </div>
+        </div>
         
         <div class="offcanvas offcanvas-end" tabindex="-1" id="sakai-quickLinksPanel" aria-labelledby="sakai-quickLinksPanelLabel">
           <div class="offcanvas-header">
             <h2 class="offcanvas-title" id="sakai-quickLinksPanelLabel">Quick Links</h2>
-            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close this quick links panel"></button>
           </div>
           <div class="offcanvas-body">
             <ul class="nav flex-column">
@@ -155,7 +181,7 @@
         <div class="offcanvas offcanvas-end" tabindex="-1" id="sakai-notificationsPanel" aria-labelledby="sakai-notificationsPanelLabel">
           <div class="offcanvas-header">
             <h2 class="offcanvas-title" id="sakai-notificationsPanelLabel">Notifications</h2>
-            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close this notifications panel"></button>
           </div>
           <div class="offcanvas-body">
             <div class="accordion" id="sakai-notificationsAccordion">
@@ -171,13 +197,13 @@
                       <li class="pe-1">
                         <div class="alert alert-light alert-dismissible fade show m-0" role="alert">
                           <a href="#">Assignment 2 is now available</a>
-                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Remove this notification"></button>
                         </div>
                       </li>
                       <li class="pe-1">
                         <div class="alert alert-light alert-dismissible fade show m-0" role="alert">
                           <a href="#">Assignment 1 has been graded and returned</a>
-                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Remove this notification"></button>
                         </div>
                       </li>
                     </ul>
@@ -196,49 +222,49 @@
                       <li class="pe-1">
                         <div class="alert alert-light alert-dismissible fade show m-0" role="alert">
                           <a href="#">Someone commented on your post "Lesson 2..."</a>
-                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Remove this notification"></button>
                         </div>
                       </li>
                       <li class="pe-1">
                         <div class="alert alert-light alert-dismissible fade show m-0" role="alert">
                           <a href="#">Someone replied to your comment on "Lesson 5..."</a>
-                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Remove this notification"></button>
                         </div>
                       </li>
                       <li class="pe-1">
                         <div class="alert alert-light alert-dismissible fade show m-0" role="alert">
                           <a href="#">Someone replied to your post "Introductions"</a>
-                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Remove this notification"></button>
                         </div>
                       </li>
                       <li class="pe-1">
                         <div class="alert alert-light alert-dismissible fade show m-0" role="alert">
                           <a href="#">Someone replied to your post "Lesson 6..."</a>
-                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Remove this notification"></button>
                         </div>
                       </li>
                       <li class="pe-1">
                         <div class="alert alert-light alert-dismissible fade show m-0" role="alert">
                           <a href="#">Someone replied to your comment on "Lesson 5..."</a>
-                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Remove this notification"></button>
                         </div>
                       </li>
                       <li class="pe-1">
                         <div class="alert alert-light alert-dismissible fade show m-0" role="alert">
                           <a href="#">Someone replied to your commment on "Lesson 5..."</a>
-                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Remove this notification"></button>
                         </div>
                       </li>
                       <li class="pe-1">
                         <div class="alert alert-light alert-dismissible fade show m-0" role="alert">
                           <a href="#">Someone replied to your comment on "Lesson 5..."</a>
-                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Remove this notification"></button>
                         </div>
                       </li>
                       <li class="pe-1">
                         <div class="alert alert-light alert-dismissible fade show m-0" role="alert">
                           <a href="#">Someone replied to your comment on "Lesson 1..."</a>
-                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Remove this notification"></button>
                         </div>
                       </li>
                     </ul>
@@ -253,7 +279,7 @@
           <div class="offcanvas-header">
             <h2 class="offcanvas-title visually-hidden" id="sakai-accountPanelLabel">Account Menu</h2>
             <span>&nbsp;</span>
-            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close this account menu"></button>
           </div>
           
           <div class="offcanvas-body position-relative">
@@ -287,6 +313,7 @@
                           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-right-square" viewBox="0 0 16 16">
                             <path fill-rule="evenodd" d="M15 2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2zM0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm4.5 5.5a.5.5 0 0 0 0 1h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5H4.5z"/>
                           </svg>
+                          <span class="visually-hidden">View this task in the course site</span>
                         </button>
                       </li>
                       <li class="sakai-task list-group-item d-flex justify-content-between">
@@ -298,6 +325,7 @@
                           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-right-square" viewBox="0 0 16 16">
                             <path fill-rule="evenodd" d="M15 2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2zM0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm4.5 5.5a.5.5 0 0 0 0 1h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5H4.5z"/>
                           </svg>
+                          <span class="visually-hidden">View this task in the course site</span>
                         </button>
                       </li>
                       <li class="sakai-task list-group-item d-flex justify-content-between">
@@ -309,6 +337,7 @@
                           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-right-square" viewBox="0 0 16 16">
                             <path fill-rule="evenodd" d="M15 2a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2zM0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm4.5 5.5a.5.5 0 0 0 0 1h5.793l-2.147 2.146a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 1 0-.708.708L10.293 7.5H4.5z"/>
                           </svg>
+                          <span class="visually-hidden">View this task in the course site</span>
                         </button>
                       </li>
                     </ul>
@@ -431,12 +460,26 @@
         </div>
       </header>
           
-      <aside class="sakai-navSidebar position-relative bg-light border-end">
-        <nav id="sitesList" class="sakai-sitesAndToolsNav" aria-label="Sites and Tools Links">
+      <aside class="sakai-navSidebar position-fixed bg-light border-end">
+        <nav id="sitesList" class="sakai-sitesAndToolsNav" aria-label="Your pinned and recent sites: expand a site to access links to its tools.">
+          <ul class="sakai-homeSite mb-0 list-unstyled">
+            <li class="my-2">
+              <button class="btn d-inline-flex align-items-center collapsed" data-bs-toggle="collapse" data-bs-target="#sakai-homeSite" aria-expanded="false" aria-controls="sakai-homeSite">Home</button>
+              <div id="sakai-homeSite" class="collapse">
+                <ul class="nav flex-column">
+                  <li class="nav-item"><a class="nav-link ps-5" href="#">Dashboard</a></li>
+                  <li class="nav-item"><a class="nav-link ps-5" href="#">My Sites</a></li>
+                  <li class="nav-item"><a class="nav-link ps-5" href="#">My Account</a></li>
+                  <li class="nav-item"><a class="nav-link ps-5" href="#">My Resources</a></li>
+                  <li class="nav-item"><a class="nav-link ps-5" href="#">My Calendar</a></li>
+                </ul>
+              </div>
+            </li>
+          </ul>
           
-          <h2 class="mb-2 pt-3 ps-3 fs-5 visually-hidden">Pinned Sites</h2>
+          <h2 class="mb-2 pt-3 ps-3 fs-5">Your Pinned Sites</h2>
           
-          <ul class="sakai-pinnedSites list-unstyled">
+          <ul class="sakai-pinnedSites mb-0 list-unstyled">
             <li class="my-2">
               <button class="btn d-inline-flex align-items-center collapsed" data-bs-toggle="collapse" data-bs-target="#sakai-pinnedSite1" aria-expanded="false" aria-controls="sakai-pinnedSite1">NURSING 380 001 SP22</button>
               <div id="sakai-pinnedSite1" class="collapse">
@@ -449,7 +492,7 @@
                 </ul>
               </div>
             </li>
-            <li id="currentSitesTools" class="my-2">
+            <li id="currentSitesTools" class="my-2" aria-current="true">
               <button class="btn d-inline-flex align-items-center active" data-bs-toggle="collapse" data-bs-target="#sakai-pinnedSite2" aria-expanded="true" aria-controls="sakai-pinnedSite2">CALCULUS 101 001 SP22</button>
               <div id="sakai-pinnedSite2" class="collapse show">
                 <ul class="nav flex-column">
@@ -487,7 +530,7 @@
             </li>
           </ul>
           
-          <h2 class="mb-2 pt-3 ps-3 fs-5">Recent Sites</h2>
+          <h2 class="mb-2 pt-3 ps-3 fs-5">Your Recent Sites</h2>
           
           <ul class="sakai-recentSites list-unstyled mb-5">
             <li class="my-2">
@@ -528,7 +571,7 @@
           
       <main class="sakai-mainContent d-flex flex-column p-3">
         <div class="sakai-pageHeader d-flex justify-content-between align-items-end mb-3 border-bottom">
-          <nav class="sakai-pageNav" aria-label="Breadcrumbs" style="--bs-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8'%3E%3Cpath d='M2.5 0L1 1.5 3.5 4 1 6.5 2.5 8l4-4-4-4z' fill='currentColor'/%3E%3C/svg%3E&#34;);">
+          <nav class="sakai-pageNav" aria-label="Breadcrumbs hierarchy of parent links to this page" style="--bs-breadcrumb-divider: url(&#34;data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='currentColor' class='bi bi-chevron-right' viewBox='0 0 16 16'%3E%3Cpath fill-rule='evenodd' d='M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708z'/%3E%3C/svg%3E&#34;);">
             <ol class="breadcrumb mb-2">
               <li class="breadcrumb-item"><a class="text-decoration-none" href="#"><small>Home</small></a></li>
               <li class="breadcrumb-item"><a class="text-decoration-none" href="#"><small>CALCULUS 101 001 SP22</small></a></li>
@@ -538,19 +581,30 @@
             <h1 id="mainContent" class="fs-2 fw-normal">Assignments List</h1>
           
           </nav>
-          
-          <ul class="sakai-toolPages nav nav-tabs flex-nowrap border-bottom-0">
-            <li class="nav-item">
-              <a class="nav-link" href="#">Grade Report</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="#">Permissions</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="#">Trash</a>
-            </li>
-          </ul>
-          
+
+          <div class="d-flex flex-column align-items-end">
+            <div class="dropdown">
+              <button class="btn dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
+                View Site
+              </button>
+              <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+                <li><a class="dropdown-item" href="#">as Student role</a></li>
+                <li><a class="dropdown-item" href="#">as Teaching Assistant role</a></li>
+              </ul>
+            </div>
+            
+            <ul class="sakai-toolPages nav nav-tabs flex-nowrap border-bottom-0">
+              <li class="nav-item">
+                <a class="nav-link" href="#">Grade Report</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="#">Permissions</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="#">Trash</a>
+              </li>
+            </ul>
+          </div>
         </div>
         
         <p>
@@ -583,6 +637,55 @@
             <tr>
               <td><input type="checkbox"/></td>
               <td colspan="4" style="text-align:center"><strong>Michael's table will go here</strong></td>
+            </tr>
+            <tr>
+              <td><input type="checkbox"/></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><input type="checkbox"/></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><input type="checkbox"/></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><input type="checkbox"/></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><input type="checkbox"/></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><input type="checkbox"/></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><input type="checkbox"/></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
             </tr>
             <tr>
               <td><input type="checkbox"/></td>

--- a/sakai-trinity/bootstrap/styles/portal.css
+++ b/sakai-trinity/bootstrap/styles/portal.css
@@ -34,10 +34,13 @@ a, .nav-link {
 }
 .sakai-navSidebar {
   grid-area: toolbar;
+  top: var(--sakai-headerHeight);
+  width: var(--sakai-navSidebar);
   height: calc(100vh - var(--sakai-headerHeight));
 }
 .sakai-mainContent {
   grid-area: main;
+  min-height: calc(100vh - var(--sakai-headerHeight));
 }
 .sakai-jumpLinks {
   padding-left: var(--sakai-navSidebar);
@@ -67,11 +70,12 @@ a, .nav-link {
 .sakai-sitesAndToolsNav {
   height: 100%;
   overflow-y: auto;
+  overscroll-behavior: contain;
 }
 .sakai-sitesAndToolsNav .btn::before {
   width:1.25em;
   line-height:0;
-  content:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='rgba%280,0,0,.5%29' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M5 14l6-6-6-6'/%3e%3c/svg%3e");
+  content:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='currentColor' class='bi bi-caret-right-fill' viewBox='0 0 16 16'%3E%3Cpath d='m12.14 8.753-5.482 4.796c-.646.566-1.658.106-1.658-.753V3.204a1 1 0 0 1 1.659-.753l5.48 4.796a1 1 0 0 1 0 1.506z'/%3E%3C/svg%3E");
   transition:transform 0.35s ease;
   transform-origin:.5em 50%
 }
@@ -89,6 +93,14 @@ a, .nav-link {
 .sakai-sitesAndToolsNav .active {
   color: #000;
   font-weight: bold;
+}
+.sakai-toolPages.nav-tabs .nav-link {
+  border-width: 0 0 4px 0;
+  border-radius: 0;
+}
+.sakai-toolPages.nav-tabs .nav-link:focus, .sakai-toolPages.nav-tabs .nav-link:hover {
+  margin-bottom: -4px;
+  border-color: transparent transparent var(--bs-primary) transparent;
 }
 .sakai-footer .nav-link {
   padding-top: 0;


### PR DESCRIPTION
- moved Search bar into an offcanvas panel and put it with the offcanvas links
- moved the System Alert away from the offcanvas links
- added more context to the aria-labels wording and added more labels throughout the mockup to describe various elements
- set SVGs to role="img" so they wouldn't be read as numbers to screenreaders
- changed the arrow icons for the breadcrumbs and sites sidebar
- added Home to the sites sidebar
- added View As dropdown
- styled the page tabs to look like the original mockup
- fixed issues with the variable length of the sidebar compared to the length of the main content area so both panels would be full-length and the footer would always be at the botttom